### PR TITLE
Add unicode string header to avoid NON-ASCII error

### DIFF
--- a/anago/data/preprocess.py
+++ b/anago/data/preprocess.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import itertools
 import re
 


### PR DESCRIPTION
Thanks for creating and sharing this repo!

Just a minor update to avoid SyntaxError with non-ascii characters (python 2) e.g. in line 137:
`SyntaxError: Non-ASCII character '\xef'`