### PR TITLE
Fix AttributeError: 'ChainCRF' object has no attribute 'inbound_nodes'

### DIFF
--- a/anago/layers.py
+++ b/anago/layers.py
@@ -273,8 +273,8 @@ class ChainCRF(Layer):
 
     def _fetch_mask(self):
         mask = None
-        if self.inbound_nodes:
-            mask = self.inbound_nodes[0].input_masks[0]
+        if self._inbound_nodes:
+            mask = self._inbound_nodes[0].input_masks[0]
         return mask
 
     def build(self, input_shape):


### PR DESCRIPTION
This problem is present in Keras 2.1.3, since self.inbound_nodes was changed for self._inbound_nodes #25 