### PR TITLE
Fix protobuf requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ idna==2.6
 Keras==2.1.3
 Markdown==2.6.9
 numpy==1.13.3
-protobuf==3.5.0
+protobuf==3.5.1
 python-dateutil==2.6.0
 pytz==2017.2
 PyYAML==3.12


### PR DESCRIPTION
Update protobuf requirement to 3.5.1 to avoid this error when installing the requirements for development of anago:

```
Could not find a version that satisfies the requirement protobuf==3.5.0 (from -r requirements.txt (line 15)) (from versions: 2.0.0b0, 2.0.3, 2.3.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, 3.0.0a2, 3.0.0a3, 3.0.0b1, 3.0.0b1.post1, 3.0.0b1.post2, 3.0.0b2, 3.0.0b2.post1, 3.0.0b2.post2, 3.0.0b3, 3.0.0b4, 3.0.0, 3.1.0, 3.1.0.post1, 3.2.0rc1, 3.2.0rc1.post1, 3.2.0rc2, 3.2.0, 3.3.0, 3.4.0, 3.5.0.post1, 3.5.1)
No matching distribution found for protobuf==3.5.0 (from -r requirements.txt (line 15))
```