### PR TITLE
Use markdown instead of reStructuredText for readme.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ h5py==2.7.1
 html5lib==0.9999999
 idna==2.6
 Keras==2.1.3
+m2r==0.1.12
 Markdown==2.6.9
 numpy==1.13.3
 protobuf==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import io
 import os
 import sys
 
 from setuptools import find_packages, setup
+from m2r import parse_from_file
 
 # Package meta-data.
 NAME = 'anago'
@@ -15,8 +15,8 @@ AUTHOR = 'Hironsan'
 LICENSE = 'MIT'
 
 here = os.path.abspath(os.path.dirname(__file__))
-with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = '\n' + f.read()
+
+long_description = parse_from_file(os.path.join(here, 'README.md'))
 
 about = {}
 with open(os.path.join(here, NAME, '__version__.py')) as f:


### PR DESCRIPTION
PyPI doesn't support Markdown in long_description, so we use m2r to convert our markdown file to reStructuredText before and set that to our long_description in setup.py.