### PR TITLE
fixes load_glove on Windows

### DIFF
--- a/anago/utils.py
+++ b/anago/utils.py
@@ -274,7 +274,7 @@ def load_glove(file):
         dict: a dict of numpy arrays.
     """
     model = {}
-    with open(file) as f:
+    with open(file, encoding="utf8", errors='ignore') as f:
         for line in f:
             line = line.split(' ')
             word = line[0]


### PR DESCRIPTION
Hi! This is a small fix to the load_glove function so that it works on Windows per this issue: https://stackoverflow.com/questions/9233027/unicodedecodeerror-charmap-codec-cant-decode-byte-x-in-position-y-character